### PR TITLE
Fix CSV export quoting

### DIFF
--- a/index.html
+++ b/index.html
@@ -2021,7 +2021,7 @@ function handlePlanUpload(e) {
             let csvContent = "data:text/csv;charset=utf-8,";
             
             data.forEach(rowArray => {
-                let row = rowArray.map(item => `"${String(item).replace(/"/g, '""')}"`).join(",");
+                let row = rowArray.map(item => `"${String(item).replace(/\"/g, '\"\"')}"`).join(",");
                 csvContent += row + "\r\n";
             });
 


### PR DESCRIPTION
## Summary
- properly escape double quotes in `exportAsCsv`

## Testing
- `node - <<'EOF'
const rowArray = ['Quote "A" inside', 'Another'];
let row = rowArray.map(item => `"${String(item).replace(/\\"/g, '\\"\\"')}"`).join(',');
console.log(row);
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687a92067d14832ea0d2ab7b02c182bd