### PR TITLE
Add Jest tests and modularize calculator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Construction Estimator
+
+This project uses Jest for unit testing.
+
+## Running Tests
+
+Install dependencies once and run the test suite with:
+
+```bash
+npm install
+npm test
+```

--- a/__tests__/calculator.test.js
+++ b/__tests__/calculator.test.js
@@ -1,0 +1,45 @@
+import { calculate, handleUnitConversion } from '../calculator.js';
+
+describe('calculate', () => {
+  test('adds numbers', () => {
+    expect(calculate(2, 3, '+')).toBe(5);
+  });
+
+  test('subtracts numbers', () => {
+    expect(calculate(5, 2, '-')).toBe(3);
+  });
+
+  test('multiplies numbers', () => {
+    expect(calculate(4, 3, '*')).toBe(12);
+  });
+
+  test('divides numbers', () => {
+    expect(calculate(10, 2, '/')).toBe(5);
+  });
+
+  test('division by zero gives Infinity', () => {
+    expect(calculate(5, 0, '/')).toBe(Infinity);
+  });
+
+  test('unknown operator returns second operand', () => {
+    expect(calculate(1, 7, '?')).toBe(7);
+  });
+});
+
+describe('handleUnitConversion', () => {
+  test('feet to inches', () => {
+    expect(handleUnitConversion(2, 'ft', 'in')).toBe(24);
+  });
+
+  test('inches to feet', () => {
+    expect(handleUnitConversion(24, 'in', 'ft')).toBe(2);
+  });
+
+  test('sqft to sqyd', () => {
+    expect(handleUnitConversion(9, 'sqft', 'sqyd')).toBe(1);
+  });
+
+  test('invalid conversion throws', () => {
+    expect(() => handleUnitConversion(1, 'm', 'ft')).toThrow('Invalid unit conversion');
+  });
+});

--- a/calculator.js
+++ b/calculator.js
@@ -1,0 +1,21 @@
+export function calculate(first, second, op) {
+  if (op === '+') return first + second;
+  if (op === '-') return first - second;
+  if (op === '*') return first * second;
+  if (op === '/') return first / second;
+  return second;
+}
+
+export function handleUnitConversion(value, fromUnit, toUnit) {
+  const conversions = {
+    'ft-in': val => val * 12,
+    'in-ft': val => val / 12,
+    'sqft-sqyd': val => val / 9,
+    'sqyd-sqft': val => val * 9,
+  };
+  const key = `${fromUnit}-${toUnit}`;
+  if (!conversions[key]) {
+    throw new Error('Invalid unit conversion');
+  }
+  return conversions[key](value);
+}

--- a/index.html
+++ b/index.html
@@ -1298,23 +1298,24 @@
     <!-- Toast Container -->
     <div id="toastContainer"></div>
 
-    <script>
-    (function() {
-        'use strict';
+    <script type="module">
+        import { calculate as calc, handleUnitConversion as convertUnits } from "./calculator.js";
+        (function() {
+            'use strict';
 
-        // --- STATE MANAGEMENT ---
-        const state = {
-            currentTab: 'dashboard',
-            materialPrices: {},
-            savedProjects: [],
-            companyInfo: { name: '', address: '', phone: '', email: '' },
-            currentEstimate: null,
-            editingProjectId: null,
-            lineItemId: 0,
-            lastFocusedInput: null,
-            calcMode: "basic",
-            calculator: {
-                displayValue: '0',
+            // --- STATE MANAGEMENT ---
+            const state = {
+                currentTab: 'dashboard',
+                materialPrices: {},
+                savedProjects: [],
+                companyInfo: { name: '', address: '', phone: '', email: '' },
+                currentEstimate: null,
+                editingProjectId: null,
+                lineItemId: 0,
+                lastFocusedInput: null,
+                calcMode: "basic",
+                calculator: {
+                    displayValue: '0',
                 firstOperand: null,
                 waitingForSecondOperand: false,
                 operator: null
@@ -1443,7 +1444,7 @@
             
             // Calculator
             document.getElementById('calculatorGrid')?.addEventListener('click', handleCalculatorClick);
-            document.getElementById('convertUnitBtn')?.addEventListener('click', handleUnitConversion);
+            document.getElementById('convertUnitBtn')?.addEventListener('click', onConvertUnit);
             document.getElementById('useValueBtn')?.addEventListener('click', useCalculatorValue);
             document.getElementById('modeBasic')?.addEventListener('click', () => updateCalcMode('basic'));
             document.getElementById('modeEngineering')?.addEventListener('click', () => updateCalcMode('engineering'));
@@ -1857,21 +1858,13 @@
             if (firstOperand == null && !isNaN(inputValue)) {
                 state.calculator.firstOperand = inputValue;
             } else if (operator) {
-                const result = calculate(firstOperand, inputValue, operator);
+                const result = calc(firstOperand, inputValue, operator);
                 state.calculator.displayValue = `${parseFloat(result.toFixed(7))}`;
                 state.calculator.firstOperand = result;
             }
             
             state.calculator.waitingForSecondOperand = true;
             state.calculator.operator = nextOperator;
-        }
-
-        function calculate(first, second, op) {
-            if (op === '+') return first + second;
-            if (op === '-') return first - second;
-            if (op === '*') return first * second;
-            if (op === '/') return first / second;
-            return second;
         }
 
         function resetCalculator() {
@@ -1881,30 +1874,21 @@
             state.calculator.operator = null;
         }
         
-        function handleUnitConversion() {
-            const fromUnit = document.getElementById('unitFrom').value;
-            const toUnit = document.getElementById('unitTo').value;
-            let value = parseFloat(state.calculator.displayValue);
-            let result = value;
-
-            const conversions = {
-                'ft-in': val => val * 12,
-                'in-ft': val => val / 12,
-                'sqft-sqyd': val => val / 9,
-                'sqyd-sqft': val => val * 9,
-            };
-            
-            const key = `${fromUnit}-${toUnit}`;
-            if (conversions[key]) {
-                result = conversions[key](value);
-            } else {
-                showToast('Invalid unit conversion', 'error');
+        function onConvertUnit() {
+            const fromUnit = document.getElementById("unitFrom").value;
+            const toUnit = document.getElementById("unitTo").value;
+            const value = parseFloat(state.calculator.displayValue);
+            let result;
+            try {
+                result = convertUnits(value, fromUnit, toUnit);
+            } catch (e) {
+                showToast("Invalid unit conversion", "error");
                 return;
             }
-            
             state.calculator.displayValue = String(parseFloat(result.toFixed(5)));
             updateCalculatorDisplay();
         }
+
         
         function useCalculatorValue() {
             if (!state.lastFocusedInput) {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ce",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "devDependencies": {
+    "jest": "^30.0.4"
+  }
+}


### PR DESCRIPTION
## Summary
- create simple Jest setup with package.json
- extract calculator logic into `calculator.js`
- import the module in `index.html`
- add unit tests for arithmetic and conversions
- document how to run the tests
- remove lock file and ignore it
- rename conversion handler to avoid confusion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a9204d778832e96deae7fc3f63f8a